### PR TITLE
fixed reading of mqtt user/pass from web form entry

### DIFF
--- a/wharehauora-wifi-gateway/wharehauora-wifi-gateway.ino
+++ b/wharehauora-wifi-gateway/wharehauora-wifi-gateway.ino
@@ -4,53 +4,73 @@
 #include <ESP8266WiFi.h>
 #define AP_NAME "WhareSensor"
 
-const char* my_ssid = "";
-const char* my_pass = "";
-const char* my_server = "m12.cloudmqtt.com";
+const char my_ssid[] = "";
+const char my_pass[] = "";
+const char my_server[] = "m11.cloudmqtt.com";
 
-char* mqtt_username = "";
-char* mqtt_password = "";
+char mqtt_username[32];
+char mqtt_password[32];
 
 #define MY_RF24_CS_PIN 2
 
 #define MY_DEBUG
-#define MY_BAUD_RATE 9600
+
+#define MY_BAUD_RATE 115200
 #define MY_RADIO_NRF24
 #define MY_GATEWAY_ESP8266
 #define MY_GATEWAY_MQTT_CLIENT
-#define MY_MQTT_CLIENT_ID "whare"
+#define MY_MQTT_CLIENT_ID mqtt_username
 #define MY_ESP8266_SSID my_ssid
 #define MY_ESP8266_PASSWORD my_pass
 #define MY_CONTROLLER_URL_ADDRESS my_server
-#define MY_MQTT_PUBLISH_TOPIC_PREFIX "/sensors"
-#define MY_MQTT_SUBSCRIBE_TOPIC_PREFIX "/actuators"
+#define MY_MQTT_PUBLISH_TOPIC_PREFIX "/sensors/wharehauora/5"
+#define MY_MQTT_SUBSCRIBE_TOPIC_PREFIX "/sensors/wharehauora/5"
 #define MY_MQTT_USER mqtt_username
 #define MY_MQTT_PASSWORD mqtt_password
-//#define MY_PORT 11223 //not-ssl
-#define MY_PORT 21223 // SSL
+#define MY_PORT 16259 //not-ssl
+//#define MY_PORT 26259 /// SSL
 
 #include <MySensors.h>
 
-void saveConfigCallback() {
-  //TODO - save the username+pass
+bool shouldSaveConfig = false;
+
+//callback notifying us of the need to save config
+void saveConfigCallback () {
+  Serial.println("Should save config");
+  shouldSaveConfig = true;
+}
+
+
+void configModeCallback (WiFiManager *myWiFiManager) {
+  Serial.println("Entered config mode");
+  Serial.println(WiFi.softAPIP());
+
+  Serial.println(myWiFiManager->getConfigPortalSSID());
 }
 
 void before() {
+  Serial.println("Entering config mode");
+
   WiFiManager wifiManager;
-//  wifiManager.resetSettings();    //reset settings - uncomment this when testing.
+  //  wifiManager.resetSettings();    // reset settings - uncomment this when testing.
   wifiManager.setTimeout(5* 60);  // wait 30 seconds
+
+
+  wifiManager.setAPCallback(configModeCallback);
+
+  //set config save notify callback
+  wifiManager.setSaveConfigCallback(saveConfigCallback);
 
   WiFiManagerParameter custom_text("<p>Whare Hauora login</p>");
   wifiManager.addParameter(&custom_text);
 
-  WiFiManagerParameter whare_mqtt_username("mqtt_username", "your email", mqtt_username, 32);
-  WiFiManagerParameter whare_mqtt_password("mqtt_password", "whare hauora password", mqtt_password, 32);
+  WiFiManagerParameter whare_mqtt_username("mqtt_username", "username", mqtt_username, 32);
+  WiFiManagerParameter whare_mqtt_password("mqtt_password", "pass code", mqtt_password, 32);
 
   wifiManager.addParameter(&whare_mqtt_username);
   wifiManager.addParameter(&whare_mqtt_password);
 
-  //set config save notify callback
-  wifiManager.setSaveConfigCallback(saveConfigCallback);
+
   if (!wifiManager.startConfigPortal(AP_NAME)) {
     Serial.println("failed to connect and hit timeout");
     delay(3000);
@@ -59,8 +79,14 @@ void before() {
     delay(5000);
   }
 
-  Serial.print("mqtt_username is "); Serial.println(whare_mqtt_username.getValue());
-  Serial.print("mqtt_password is "); Serial.println(whare_mqtt_password.getValue());
+  Serial.print("whare_mqtt_username is "); Serial.println(whare_mqtt_username.getValue());
+  Serial.print("whare_mqtt_password is "); Serial.println(whare_mqtt_password.getValue());
+
+
+  strcpy(mqtt_username, whare_mqtt_username.getValue());
+  strcpy(mqtt_password, whare_mqtt_password.getValue());
+  Serial.print("mqtt_username is "); Serial.println(mqtt_username);
+  Serial.print("mqtt_password is "); Serial.println(mqtt_password);
 }
 
 void setup() {
@@ -71,5 +97,3 @@ void presentation() {
 
 void loop() {
 }
-
-


### PR DESCRIPTION
the Gateways needs to log in as a Home, not a User. -- so we know which Home to associate the sensors to. (a User may have many homes).

This fixes logging in to MQTT with the user entered on the webform, and changes the field description to be "username" and "pass code"
